### PR TITLE
Improve balancing. Deleted code reduces the amount of work that needs…

### DIFF
--- a/plugin/work_leader.go
+++ b/plugin/work_leader.go
@@ -129,7 +129,10 @@ func (p *WorkLeader) loop() {
 				p.removeWorker(event.Data["path"].(string))
 			}
 		case event := <-workWatchChn:
-			p.processWorkEvents(event)
+			// Don't processs this event: ChildrenWatchLoadedEvent
+			if event.Type != ChildrenWatchLoadedEvent {
+				p.processWorkEvents(event)
+			}
 		case <-p.stopChn:
 			return
 		}

--- a/plugin/work_supervisor.go
+++ b/plugin/work_supervisor.go
@@ -66,9 +66,6 @@ func (s *WorkSupervisor) AddWorker(node *Znode) (err error) {
 	if workerCount > 1 && totalWork > 0 {
 		workPerWorker := int(totalWork / workerCount)
 		workRemainder := totalWork % workerCount
-		if workRemainder != 0 {
-			workPerWorker = workPerWorker - int(workRemainder/(workerCount-1))
-		}
 		entry.WithFields(log.Fields{
 			"workerPerWorker": workPerWorker,
 			"remainder":       workRemainder,


### PR DESCRIPTION
… to shifted needlessly.

Suppose totalWork = 9.

Then this calculates to be:

> workPerWorker = 9/2 = 4
> workRemainder = 1

Removed code would reduce workPerWorker to 3, even though it really should stay at 4, as per:

> workPerWorker = 4 - (1/(2-1)) = 3
